### PR TITLE
Oldnumeric replaced by numpy, fixes #103

### DIFF
--- a/src/pyphant/pyphant/quantities/PhysicalQuantities.py
+++ b/src/pyphant/pyphant/quantities/PhysicalQuantities.py
@@ -403,21 +403,21 @@ class PhysicalQuantity:
     def sin(self):
         if self.unit.isAngle():
             return np.sin(self.value * \
-                             self.unit.conversionFactorTo(_unit_table['rad']))
+                          self.unit.conversionFactorTo(_unit_table['rad']))
         else:
             raise TypeError('Argument of sin must be an angle')
 
     def cos(self):
         if self.unit.isAngle():
             return np.cos(self.value * \
-                             self.unit.conversionFactorTo(_unit_table['rad']))
+                          self.unit.conversionFactorTo(_unit_table['rad']))
         else:
             raise TypeError('Argument of cos must be an angle')
 
     def tan(self):
         if self.unit.isAngle():
             return np.tan(self.value * \
-                             self.unit.conversionFactorTo(_unit_table['rad']))
+                          self.unit.conversionFactorTo(_unit_table['rad']))
         else:
             raise TypeError('Argument of tan must be an angle')
 

--- a/src/pyphant/pyphant/quantities/PhysicalQuantities.py
+++ b/src/pyphant/pyphant/quantities/PhysicalQuantities.py
@@ -114,11 +114,11 @@ class NumberDict(dict):
             new[key] = self[key]/other
         return new
 
-import numpy.oldnumeric
+import numpy as np
 def int_sum(a, axis=0):
-    return numpy.oldnumeric.add.reduce(a, axis)
+    return np.add.reduce(a, axis)
 def zeros_st(shape, other):
-    return numpy.oldnumeric.zeros(shape, dtype=other.dtype)
+    return np.zeros(shape, dtype=other.dtype)
 from numpy import ndarray as array_type
 
 
@@ -402,21 +402,21 @@ class PhysicalQuantity:
 
     def sin(self):
         if self.unit.isAngle():
-            return numpy.oldnumeric.sin(self.value * \
+            return np.sin(self.value * \
                              self.unit.conversionFactorTo(_unit_table['rad']))
         else:
             raise TypeError('Argument of sin must be an angle')
 
     def cos(self):
         if self.unit.isAngle():
-            return numpy.oldnumeric.cos(self.value * \
+            return np.cos(self.value * \
                              self.unit.conversionFactorTo(_unit_table['rad']))
         else:
             raise TypeError('Argument of cos must be an angle')
 
     def tan(self):
         if self.unit.isAngle():
-            return numpy.oldnumeric.tan(self.value * \
+            return np.tan(self.value * \
                              self.unit.conversionFactorTo(_unit_table['rad']))
         else:
             raise TypeError('Argument of tan must be an angle')
@@ -515,7 +515,7 @@ class PhysicalUnit:
                                 map(lambda x,p=other: x*p, self.powers))
         if isinstance(other, float):
             inv_exp = 1./other
-            rounded = int(numpy.oldnumeric.floor(inv_exp+0.5))
+            rounded = int(np.floor(inv_exp+0.5))
             if abs(inv_exp-rounded) < 1.e-10:
                 if reduce(lambda a, b: a and b,
                           map(lambda x, e=rounded: x%e == 0, self.powers)):
@@ -660,10 +660,10 @@ def _findUnit(unit):
     return unit
 
 def _round(x):
-    if numpy.oldnumeric.greater(x, 0.):
-        return numpy.oldnumeric.floor(x)
+    if np.greater(x, 0.):
+        return np.floor(x)
     else:
-        return numpy.oldnumeric.ceil(x)
+        return np.ceil(x)
 
 
 def _convertValue (value, src_unit, target_unit):
@@ -777,7 +777,7 @@ for unit in _unit_table.keys():
 # Fundamental constants
 _help.append('Fundamental constants:')
 
-_unit_table['pi'] = numpy.oldnumeric.pi
+_unit_table['pi'] = np.pi
 _addUnit('c', '299792458.*m/s', 'speed of light')
 _addUnit('mu0', '4.e-7*pi*N/A**2', 'permeability of vacuum')
 _addUnit('eps0', '1/mu0/c**2', 'permittivity of vacuum')

--- a/src/pyphant/pyphant/quantities/PhysicalQuantities.py
+++ b/src/pyphant/pyphant/quantities/PhysicalQuantities.py
@@ -515,9 +515,9 @@ class PhysicalUnit:
         if isinstance(other, int):
             return PhysicalUnit(other*self.names, pow(self.factor, other),
                                 map(lambda x,p=other: x*p, self.powers))
-        if isinstance(other, float):
+        if (isinstance(other, float)) and (other != 0.):
             inv_exp = 1./other
-            rounded = int(np.floor(inv_exp+0.5))
+            rounded = round(inv_exp)
             if abs(inv_exp-rounded) < 1.e-10:
                 if reduce(lambda a, b: a and b,
                           map(lambda x, e=rounded: x%e == 0, self.powers)):

--- a/src/pyphant/pyphant/quantities/PhysicalQuantities.py
+++ b/src/pyphant/pyphant/quantities/PhysicalQuantities.py
@@ -3,6 +3,8 @@
 # Copyright (c) 1998-2007, Konrad Hinsen <hinsen@cnrs-orleans.fr>
 # Copyright (c) 2008-2009, Rectorate of the University of Freiburg
 # Copyright (c) 2010, Andreas W. Liehr <liehr@users.sourceforge.net>
+# Copyright (c) 2010-2015, Servicegroup Scientific Information Processing, FMF
+# (servicegruppe.wissinfo@fmf.uni-freiburg.de)
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/pyphant/pyphant/quantities/__init__.py
+++ b/src/pyphant/pyphant/quantities/__init__.py
@@ -115,11 +115,11 @@ class NumberDict(dict):
             new[key] = self[key]/other
         return new
 
-import numpy.oldnumeric
+import numpy as np
 def int_sum(a, axis=0):
-    return numpy.oldnumeric.add.reduce(a, axis)
+    return np.add.reduce(a, axis)
 def zeros_st(shape, other):
-    return numpy.oldnumeric.zeros(shape, dtype=other.dtype)
+    return np.zeros(shape, dtype=other.dtype)
 from numpy import ndarray as array_type
 
 
@@ -444,21 +444,21 @@ class Quantity:
 
     def sin(self):
         if self.unit.isAngle():
-            return numpy.oldnumeric.sin(self.value * \
+            return np.sin(self.value * \
                              self.unit.conversionFactorTo(_unit_table['rad']))
         else:
             raise TypeError('Argument of sin must be an angle')
 
     def cos(self):
         if self.unit.isAngle():
-            return numpy.oldnumeric.cos(self.value * \
+            return np.cos(self.value * \
                              self.unit.conversionFactorTo(_unit_table['rad']))
         else:
             raise TypeError('Argument of cos must be an angle')
 
     def tan(self):
         if self.unit.isAngle():
-            return numpy.oldnumeric.tan(self.value * \
+            return np.tan(self.value * \
                              self.unit.conversionFactorTo(_unit_table['rad']))
         else:
             raise TypeError('Argument of tan must be an angle')
@@ -557,7 +557,7 @@ class PhysicalUnit:
                                 map(lambda x,p=other: x*p, self.powers))
         if isinstance(other, float):
             inv_exp = 1./other
-            rounded = int(numpy.oldnumeric.floor(inv_exp+0.5))
+            rounded = int(np.floor(inv_exp+0.5))
             if abs(inv_exp-rounded) < 1.e-10:
                 if reduce(lambda a, b: a and b,
                           map(lambda x, e=rounded: x%e == 0, self.powers)):
@@ -703,10 +703,10 @@ def _findUnit(unit):
     return unit
 
 def _round(x):
-    if numpy.oldnumeric.greater(x, 0.):
-        return numpy.oldnumeric.floor(x)
+    if np.greater(x, 0.):
+        return np.floor(x)
     else:
-        return numpy.oldnumeric.ceil(x)
+        return np.ceil(x)
 
 
 def _convertValue (value, src_unit, target_unit):
@@ -833,7 +833,7 @@ for unit in _binaryUnits:
 # Fundamental constants
 _help.append('Fundamental constants:')
 
-_unit_table['pi'] = numpy.oldnumeric.pi
+_unit_table['pi'] = np.pi
 _addUnit('c', '299792458.*m/s', 'speed of light')
 _addUnit('mu0', '4.e-7*pi*N/A**2', 'permeability of vacuum')
 _addUnit('eps0', '1/mu0/c**2', 'permittivity of vacuum')

--- a/src/pyphant/pyphant/quantities/__init__.py
+++ b/src/pyphant/pyphant/quantities/__init__.py
@@ -557,9 +557,9 @@ class PhysicalUnit:
         if isinstance(other, int):
             return PhysicalUnit(other*self.names, pow(self.factor, other),
                                 map(lambda x,p=other: x*p, self.powers))
-        if isinstance(other, float):
+        if (isinstance(other, float)) and (other != 0.):
             inv_exp = 1./other
-            rounded = int(np.floor(inv_exp+0.5))
+            rounded = round(inv_exp)
             if abs(inv_exp-rounded) < 1.e-10:
                 if reduce(lambda a, b: a and b,
                           map(lambda x, e=rounded: x%e == 0, self.powers)):

--- a/src/pyphant/pyphant/quantities/__init__.py
+++ b/src/pyphant/pyphant/quantities/__init__.py
@@ -445,21 +445,21 @@ class Quantity:
     def sin(self):
         if self.unit.isAngle():
             return np.sin(self.value * \
-                             self.unit.conversionFactorTo(_unit_table['rad']))
+                          self.unit.conversionFactorTo(_unit_table['rad']))
         else:
             raise TypeError('Argument of sin must be an angle')
 
     def cos(self):
         if self.unit.isAngle():
             return np.cos(self.value * \
-                             self.unit.conversionFactorTo(_unit_table['rad']))
+                          self.unit.conversionFactorTo(_unit_table['rad']))
         else:
             raise TypeError('Argument of cos must be an angle')
 
     def tan(self):
         if self.unit.isAngle():
             return np.tan(self.value * \
-                             self.unit.conversionFactorTo(_unit_table['rad']))
+                          self.unit.conversionFactorTo(_unit_table['rad']))
         else:
             raise TypeError('Argument of tan must be an angle')
 

--- a/src/pyphant/pyphant/quantities/__init__.py
+++ b/src/pyphant/pyphant/quantities/__init__.py
@@ -3,6 +3,8 @@
 # Copyright (c) 1998-2007, Konrad Hinsen <hinsen@cnrs-orleans.fr>
 # Copyright (c) 2008-2010, Rectorate of the University of Freiburg
 # Copyright (c) 2009-2010, Andreas W. Liehr <liehr@users.sourceforge.net>
+# Copyright (c) 2010-2015, Servicegroup Scientific Information Processing, FMF
+# (servicegruppe.wissinfo@fmf.uni-freiburg.de)
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/pyphant/pyphant/tests/TestQuantitiesNumpyOldnumeric.py
+++ b/src/pyphant/pyphant/tests/TestQuantitiesNumpyOldnumeric.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2010-2015, Servicegroup Scientific Information Processing, FMF
+# Copyright (c) 2015, Servicegroup Scientific Information Processing, FMF
 # (servicegruppe.wissinfo@fmf.uni-freiburg.de)
 # All rights reserved.
 #

--- a/src/pyphant/pyphant/tests/TestQuantitiesNumpyOldnumeric.py
+++ b/src/pyphant/pyphant/tests/TestQuantitiesNumpyOldnumeric.py
@@ -1,0 +1,175 @@
+import unittest
+from pyphant.quantities import Quantity, _unit_table, PhysicalUnit,\
+                               NumberDict, _base_names
+import numpy as np
+import numpy.oldnumeric
+
+
+def sin_new(quantity):
+    if quantity.unit.isAngle():
+        return np.sin(quantity.value * \
+                      quantity.unit.conversionFactorTo(_unit_table['rad'])
+                      )
+    else:
+        raise TypeError('Argument of sin must be an angle')
+
+
+def sin_old(quantity):
+    if quantity.unit.isAngle():
+        return numpy.oldnumeric.sin(quantity.value * \
+                                    quantity.unit.conversionFactorTo(
+                                        _unit_table['rad']
+                                        )
+                                    )
+    else:
+        raise TypeError('Argument of sin must be an angle')
+
+
+def cos_new(quantity):
+    if quantity.unit.isAngle():
+        return np.cos(quantity.value * \
+                      quantity.unit.conversionFactorTo(_unit_table['rad'])
+                      )
+    else:
+        raise TypeError('Argument of sin must be an angle')
+
+
+def cos_old(quantity):
+    if quantity.unit.isAngle():
+        return numpy.oldnumeric.cos(quantity.value * \
+                                    quantity.unit.conversionFactorTo(
+                                        _unit_table['rad']
+                                        )
+                                    )
+    else:
+        raise TypeError('Argument of sin must be an angle')
+
+
+def tan_new(quantity):
+    if quantity.unit.isAngle():
+        return np.tan(quantity.value * \
+                      quantity.unit.conversionFactorTo(_unit_table['rad'])
+                      )
+    else:
+        raise TypeError('Argument of sin must be an angle')
+
+
+def tan_old(quantity):
+    if quantity.unit.isAngle():
+        return numpy.oldnumeric.tan(quantity.value * \
+                                    quantity.unit.conversionFactorTo(
+                                        _unit_table['rad']
+                                        )
+                                    )
+    else:
+        raise TypeError('Argument of sin must be an angle')
+
+
+def pow_new(physunit, other):
+    if physunit.offset != 0:
+        raise TypeError('cannot exponentiate units with non-zero offset')
+    if isinstance(other, int):
+        return PhysicalUnit(other * physunit.names,
+                            pow(physunit.factor, other),
+                            map(lambda x, p=other: x * p, physunit.powers))
+    if (isinstance(other, float)) and (other != 0.):
+        inv_exp = 1. / other
+        rounded = round(inv_exp)
+        if abs(inv_exp - rounded) < 1.e-10:
+            if reduce(lambda a, b: a and b,
+                      map(lambda x, e=rounded: x % e == 0, physunit.powers)):
+                f = pow(physunit.factor, other)
+                p = map(lambda x, p=rounded: x / p, physunit.powers)
+                if reduce(lambda a, b: a and b,
+                          map(lambda x, e=rounded: x % e == 0,
+                              physunit.names.values())):
+                    names = physunit.names / rounded
+                else:
+                    names = NumberDict()
+                    if f != 1.:
+                        names[str(f)] = 1
+                    for i in range(len(p)):
+                        names[_base_names[i]] = p[i]
+                return PhysicalUnit(names, f, p)
+            else:
+                raise TypeError('Illegal exponent')
+    raise TypeError('Only integer and inverse integer exponents allowed')
+
+
+def pow_old(physunit, other):
+    if physunit.offset != 0:
+        raise TypeError('cannot exponentiate units with non-zero offset')
+    if isinstance(other, int):
+        return PhysicalUnit(other * physunit.names,
+                            pow(physunit.factor, other),
+                            map(lambda x, p=other: x * p, physunit.powers))
+    if isinstance(other, float):
+        inv_exp = 1. / other
+        rounded = int(numpy.oldnumeric.floor(inv_exp + 0.5))
+        if abs(inv_exp - rounded) < 1.e-10:
+            if reduce(lambda a, b: a and b,
+                      map(lambda x, e=rounded: x % e == 0, physunit.powers)):
+                f = pow(physunit.factor, other)
+                p = map(lambda x, p=rounded: x / p, physunit.powers)
+                if reduce(lambda a, b: a and b,
+                          map(lambda x, e=rounded: x % e == 0,
+                              physunit.names.values())):
+                    names = physunit.names / rounded
+                else:
+                    names = NumberDict()
+                    if f != 1.:
+                        names[str(f)] = 1
+                    for i in range(len(p)):
+                        names[_base_names[i]] = p[i]
+                return PhysicalUnit(names, f, p)
+            else:
+                raise TypeError('Illegal exponent')
+    raise TypeError('Only integer and inverse integer exponents allowed')
+
+
+class TestQuantityNumpyOldnumeric(unittest.TestCase):
+    def setUp(self):
+        self.angles = []
+        self.angles.append(Quantity('1.4 rad'))
+        self.angles.append(Quantity('2 rad'))
+        self.angles.append(Quantity('30 deg'))
+        self.angles.append(Quantity('-40 deg'))
+        self.length = Quantity('5.3 m')
+        self.phyunit = PhysicalUnit('m', 1., [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+        self.phyunit **= 5
+        self.exps = [0, 1, 2, 1. / 5, 1. / (5. + 1e-12), 1. / (5. - 1e-12)]
+        self.badexps = [0., 2., 1. / 6, 1. / (5. + 1e-8)]
+
+    def testsin(self):
+        for angle in self.angles:
+            self.assertAlmostEqual(sin_new(angle), sin_old(angle))
+        with self.assertRaises(TypeError):
+            sin_new(self.length)
+            sin_old(self.length)
+
+    def testcos(self):
+        for angle in self.angles:
+            self.assertAlmostEqual(cos_new(angle), cos_old(angle))
+        with self.assertRaises(TypeError):
+            cos_new(self.length)
+            cos_old(self.length)
+
+    def testtan(self):
+        for angle in self.angles:
+            self.assertAlmostEqual(tan_new(angle), tan_old(angle))
+        with self.assertRaises(TypeError):
+            tan_new(self.length)
+            tan_old(self.length)
+
+    def testpow(self):
+        for exp in self.exps:
+            self.assertAlmostEqual(pow_new(self.phyunit, exp),
+                                   pow_old(self.phyunit, exp)
+                                   )
+        for exp in self.badexps:
+            with self.assertRaises(TypeError):
+                pow_new(self.phyunit, exp)
+                pow_old(self.phyunit, exp)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/pyphant/pyphant/tests/TestQuantitiesNumpyOldnumeric.py
+++ b/src/pyphant/pyphant/tests/TestQuantitiesNumpyOldnumeric.py
@@ -1,3 +1,38 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2009, Rectorate of the University of Freiburg
+# Copyright (c) 2009-2010, Andreas W. Liehr (liehr@users.sourceforge.net)
+# Copyright (c) 2010-2015, Servicegroup Scientific Information Processing, FMF
+# (servicegruppe.wissinfo@fmf.uni-freiburg.de)
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+# * Neither the name of the Freiburg Materials Research Center,
+#   University of Freiburg nor the names of its contributors may be used to
+#   endorse or promote products derived from this software without specific
+#   prior written permission.
+#
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+# IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+# OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
 import unittest
 from pyphant.quantities import Quantity, _unit_table, PhysicalUnit,\
                                NumberDict, _base_names
@@ -177,8 +212,10 @@ class TestQuantityNumpyOldnumeric(unittest.TestCase):
         self.length = Quantity('5.3 m')
         self.phyunit = PhysicalUnit('m', 1., [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
         self.phyunit **= 5
-        self.exps = [0, 1, 2, 1. / 5, 1. / (5. + 1e-12), 1. / (5. - 1e-12)]
-        self.badexps = [0., 2., 1. / 6, 1. / (5. + 1e-8)]
+        self.exps = [0, 1, 2, 1. / 5, 1. / (5. + 1e-12), 1. / (5. - 1e-12),
+                     -1. / (5. + 1e-12), -1. / (5. - 1e-12)]
+        self.badexps = [0., 2., 1. / 6, 1. / (5. + 1e-8), 1. / (5. - 1e-8),
+                        -1. / (5. + 1e-8), -1. / (5. - 1e-8)]
         self.values = [0, 1, 0., 1e-10, 4.049, 10.05, 3 - 1e-10]
         self.values += [-1, -1e-10, -4.049, -10.05, -(3 - 1e-10)]
 
@@ -196,6 +233,8 @@ class TestQuantityNumpyOldnumeric(unittest.TestCase):
     def testsin(self):
         for angle in self.angles:
             self.assertAlmostEqual(sin_new(angle), sin_old(angle))
+
+    def testsin_error(self):
         with self.assertRaises(TypeError):
             sin_new(self.length)
             sin_old(self.length)
@@ -203,6 +242,8 @@ class TestQuantityNumpyOldnumeric(unittest.TestCase):
     def testcos(self):
         for angle in self.angles:
             self.assertAlmostEqual(cos_new(angle), cos_old(angle))
+
+    def testcos_error(self):
         with self.assertRaises(TypeError):
             cos_new(self.length)
             cos_old(self.length)
@@ -210,6 +251,8 @@ class TestQuantityNumpyOldnumeric(unittest.TestCase):
     def testtan(self):
         for angle in self.angles:
             self.assertAlmostEqual(tan_new(angle), tan_old(angle))
+
+    def testtan_error(self):
         with self.assertRaises(TypeError):
             tan_new(self.length)
             tan_old(self.length)
@@ -219,6 +262,8 @@ class TestQuantityNumpyOldnumeric(unittest.TestCase):
             self.assertAlmostEqual(pow_new(self.phyunit, exp),
                                    pow_old(self.phyunit, exp)
                                    )
+
+    def testpow_error(self):
         for exp in self.badexps:
             with self.assertRaises(TypeError):
                 pow_new(self.phyunit, exp)

--- a/src/pyphant/pyphant/tests/TestQuantitiesNumpyOldnumeric.py
+++ b/src/pyphant/pyphant/tests/TestQuantitiesNumpyOldnumeric.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2009, Rectorate of the University of Freiburg
-# Copyright (c) 2009-2010, Andreas W. Liehr (liehr@users.sourceforge.net)
 # Copyright (c) 2010-2015, Servicegroup Scientific Information Processing, FMF
 # (servicegruppe.wissinfo@fmf.uni-freiburg.de)
 # All rights reserved.

--- a/src/pyphant/pyphant/tests/TestQuantitiesNumpyOldnumeric.py
+++ b/src/pyphant/pyphant/tests/TestQuantitiesNumpyOldnumeric.py
@@ -5,6 +5,22 @@ import numpy as np
 import numpy.oldnumeric
 
 
+def int_sum_new(a, axis=0):
+    return np.add.reduce(a, axis)
+
+
+def int_sum_old(a, axis=0):
+    return numpy.oldnumeric.add.reduce(a, axis)
+
+
+def zeros_st_new(shape, other):
+    return np.zeros(shape, dtype=other.dtype)
+
+
+def zeros_st_old(shape, other):
+    return numpy.oldnumeric.zeros(shape, dtype=other.dtype)
+
+
 def sin_new(quantity):
     if quantity.unit.isAngle():
         return np.sin(quantity.value * \
@@ -127,8 +143,32 @@ def pow_old(physunit, other):
     raise TypeError('Only integer and inverse integer exponents allowed')
 
 
+def round_new(x):
+    if np.greater(x, 0.):
+        return np.floor(x)
+    else:
+        return np.ceil(x)
+
+
+def round_old(x):
+    if numpy.oldnumeric.greater(x, 0.):
+        return numpy.oldnumeric.floor(x)
+    else:
+        return numpy.oldnumeric.ceil(x)
+
+
 class TestQuantityNumpyOldnumeric(unittest.TestCase):
     def setUp(self):
+        self.arrays = []
+        self.arrays.append([1, 2, 3])
+        self.arrays.append([1.9, -2.2, 3.4])
+        self.matrix = [[3.8, 4.5],
+                       [-3.4, 546.6]]
+        self.shapes = []
+        self.shapes.append((5, np.array([6])))
+        self.shapes.append((5, np.array([6.])))
+        self.shapes.append(((3, 2), np.array([6])))
+        self.shapes.append(((3, 2), np.array([6.])))
         self.angles = []
         self.angles.append(Quantity('1.4 rad'))
         self.angles.append(Quantity('2 rad'))
@@ -139,6 +179,19 @@ class TestQuantityNumpyOldnumeric(unittest.TestCase):
         self.phyunit **= 5
         self.exps = [0, 1, 2, 1. / 5, 1. / (5. + 1e-12), 1. / (5. - 1e-12)]
         self.badexps = [0., 2., 1. / 6, 1. / (5. + 1e-8)]
+        self.values = [0, 1, 0., 1e-10, 4.049, 10.05, 3 - 1e-10]
+        self.values += [-1, -1e-10, -4.049, -10.05, -(3 - 1e-10)]
+
+    def testint_sum(self):
+        for array in self.arrays:
+            self.assertAlmostEqual(int_sum_new(array), int_sum_old(array))
+        self.assertAlmostEqual(int_sum_new(self.matrix).tolist(),
+                               int_sum_old(self.matrix).tolist())
+
+    def testzero_st(self):
+        for (shape, other) in self.shapes:
+            self.assertEqual(zeros_st_new(shape, other).tolist(),
+                             zeros_st_old(shape, other).tolist())
 
     def testsin(self):
         for angle in self.angles:
@@ -170,6 +223,13 @@ class TestQuantityNumpyOldnumeric(unittest.TestCase):
             with self.assertRaises(TypeError):
                 pow_new(self.phyunit, exp)
                 pow_old(self.phyunit, exp)
+
+    def testround(self):
+        for value in self.values:
+            self.assertEqual(round_new(value), round_old(value))
+
+    def testpi(self):
+        self.assertAlmostEqual(np.pi, numpy.oldnumeric.pi)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
numpy.oldnumeric functions in
.../pyphant1/src/pyphant/pyphant/quantities/__init__.py
and
.../pyphant1/src/pyphant/pyphant/quantities/PhysicalQuantities.py
were replaced by numpy functions.
A new test (TestQuantitiesNumpyOldnumeric.py) checks that the numpy functions are equal to the oldnumeric functions.